### PR TITLE
Fix student view

### DIFF
--- a/s3uploader_downloader/s3uploader_downloader.py
+++ b/s3uploader_downloader/s3uploader_downloader.py
@@ -159,7 +159,8 @@ class UploaderDownloaderXBlock(XBlock):
             frag.add_javascript(self.resource_string("static/js/src/s3.fine-uploader.core.min.js"))
             frag.add_javascript(self.resource_string("static/js/src/s3.fine-uploader.js"))
             frag.add_javascript(self.resource_string("static/js/src/s3.jquery.fine-uploader.min.js"))
-        frag.add_javascript(loader.render_template("static/js/src/s3uploader_downloader.js",context))
+            frag.add_javascript(loader.render_template("static/js/src/s3uploader_downloader.js",context))
+
         frag.initialize_js('UploaderDownloaderXBlock')
         return frag
 


### PR DESCRIPTION
If we have xblock with staff only access, we get error on student view 
```Uncaught ReferenceError: qq is not defined```
This is because we were not loading some JS files. I have moved all related js files behind the condition. 